### PR TITLE
Update SimpleUDFExample.java

### DIFF
--- a/src/main/java/com/matthewrathbone/example/SimpleUDFExample.java
+++ b/src/main/java/com/matthewrathbone/example/SimpleUDFExample.java
@@ -10,7 +10,7 @@ import org.apache.hadoop.io.Text;
   value="returns 'hello x', where x is whatever you give it (STRING)",
   extended="SELECT simpleudfexample('world') from foo limit 1;"
   )
-class SimpleUDFExample extends UDF {
+public class SimpleUDFExample extends UDF {
   
   public Text evaluate(Text input) {
     if(input == null) return null;


### PR DESCRIPTION
It gives error when defined in Hive without public declaration.

"Error: FAILED: SemanticException [Error 10014]: Line 1:7 Wrong arguments 'name': Unable to instantiate UDF implementation class com.matthewrathbone.example.SimpleUDFExample: java.lang.IllegalAccessException: Class org.apache.hadoop.hive.ql.udf.generic.GenericUDFBridge can not access a member of class com.matthewrathbone.example.SimpleUDFExample with modifiers """